### PR TITLE
Quality Gate Type Check Param for selection

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,14 +19,14 @@ steps:
     when:
       ref:
         - "refs/pull/**" # Only run for pull requests
-  - name: publish-2.1.0
+  - name: publish-2.1.1
     image: plugins/docker:20
     settings:
       # auto_tag: true
       # auto_tag_suffix: v2.0.2-java17
       tags:
-        - v2.1.0
-        - latest
+        - v2.1.1
+        # - latest
         # - stable-java17
       daemon_off: false
       dockerfile: Dockerfile

--- a/main.go
+++ b/main.go
@@ -109,6 +109,12 @@ func main() {
 			EnvVar: "PLUGIN_SONAR_QUALITY_ENABLED",
 		},
 		cli.StringFlag{
+			Name:   "quality_gate_type",
+			Usage:  "if this setting is not set the default is analysisID, if you want to use other QG checks then choose: branch, pullRequest or projectKey",
+			Value:  "analysisID",
+			EnvVar: "PLUGIN_QG_TYPE",
+		},
+		cli.StringFlag{
 			Name:   "qualitygate_timeout",
 			Usage:  "number in seconds for timeout",
 			Value:  "300",

--- a/plugin.go
+++ b/plugin.go
@@ -658,9 +658,36 @@ func staticScan(p *Plugin) (*SonarReport, error) {
 }
 
 func getStatus(task *TaskResponse, report *SonarReport) string {
-	reportRequest := url.Values{
-		"analysisId": {task.Task.AnalysisID},
+
+	qg_type := os.Getenv("PLUGIN_QG_TYPE")
+
+	var reportRequest url.Values
+
+	if qg_type == "branch" {
+		qg_branch := os.Getenv("PLUGIN_BRANCH")
+		reportRequest = url.Values{
+			"branch": {qg_branch},
+		}
+	} else if qg_type == "pullRequest" {
+		qg_pr := os.Getenv("PLUGIN_PR_KEY")
+		reportRequest = url.Values{
+			"pullRequest": {qg_pr},
+		}
+
+	} else if qg_type == "projectKey" {
+		qg_projectKey := os.Getenv("PLUGIN_SONAR_KEY")
+		reportRequest = url.Values{
+			"projectKey": {qg_projectKey},
+		}
+	} else {
+		reportRequest = url.Values{
+			"analysisId": {task.Task.AnalysisID},
+		}
 	}
+
+	// reportRequest := url.Values{
+	// 	"analysisId": {task.Task.AnalysisID},
+	// }
 	sonarToken := os.Getenv("PLUGIN_SONAR_TOKEN")
 
 	// First try with Basic Auth


### PR DESCRIPTION
if this setting is not set the default is analysisID, if you want to use other QG checks then choose: branch, pullRequest or projectKey.

new param: qg_type

values: branch, pullRequest and projectKey

in settings would be like this:

```
                    - step:
                        type: Plugin
                        name: Check Sonar Quality Gate
                        identifier: run_sonar
                        spec:
                          connectorRef: account.DockerHubDiego
                          image: diegokoala/harness-cie-sonarqube-scanner:stable-ba82a3c
                          privileged: false
                          reports:
                            type: JUnit
                            spec:
                              paths:
                                - sonarResults.xml
                          settings:
                            sonar_host: https://sonar.harness-demo.site
                            sonar_token: <+secrets.getValue("account.harnesssonartoken")>
                            sources: /harness
                            binaries: /harness/binary
                            sonar_name: <+pipeline.properties.ci.codebase.repoName>
                            sonar_key: <+pipeline.properties.ci.codebase.repoName>
                            skip_scan: "false"
                            qg_type: "projectKey"
                          imagePullPolicy: Always
                        failureStrategies:
                          - onFailure:
                              errors:
                                - AllErrors
                              action:
                                type: Ignore
```