### PR TITLE
Make waiting optional

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -409,7 +409,7 @@ func (p Plugin) Exec() error {
 	// Initial values
 	args := []string{
 		"-Dsonar.host.url=" + p.Config.Host,
-		"-Dsonar.login=" + p.Config.Token,
+		"-Dsonar.token=" + p.Config.Token,
 	}
 
 	// Map of potential configurations

--- a/plugin.go
+++ b/plugin.go
@@ -550,29 +550,40 @@ func (p Plugin) Exec() error {
 				"error": err,
 			}).Fatal("Unable to parse scan results!")
 		}
-		logrus.WithFields(logrus.Fields{
-			"job url": report.CeTaskURL,
-		}).Info("Job url")
-		fmt.Printf("\n")
-		fmt.Printf("\n\nWaiting Analysis to finish:\n\n")
-		fmt.Printf("\n")
 
-		task, err := waitForSonarJob(report)
-
-		if err != nil {
+		if p.Config.WaitQualityGate {
 			logrus.WithFields(logrus.Fields{
-				"error": err,
-			}).Fatal("Unable to get Job state")
-			return err
+				"job url": report.CeTaskURL,
+			}).Info("Job url")
+			fmt.Printf("\n")
+			fmt.Printf("\n\nWaiting Analysis to finish:\n\n")
+			fmt.Printf("\n")
+
+			task, err := waitForSonarJob(report)
+
+			if err != nil {
+				logrus.WithFields(logrus.Fields{
+					"error": err,
+				}).Fatal("Unable to get Job state")
+				return err
+			}
+
+			fmt.Printf("\n")
+			fmt.Printf("#######################################\n")
+			fmt.Printf("Waiting for quality gate validation...\n")
+			fmt.Printf("#######################################\n")
+			fmt.Printf("\n")
+
+			status = getStatus(task, report)
+		} else {
+			fmt.Printf("\n")
+			fmt.Printf("#######################################\n")
+			fmt.Printf("Delaying for quality gate validation...\n")
+			fmt.Printf("#######################################\n")
+			fmt.Printf("\n")
+
+			status = "OK"
 		}
-
-		fmt.Printf("\n")
-		fmt.Printf("#######################################\n")
-		fmt.Printf("Waiting for quality gate validation...\n")
-		fmt.Printf("#######################################\n")
-		fmt.Printf("\n")
-
-		status = getStatus(task, report)
 	}
 
 	fmt.Printf("\n")
@@ -596,7 +607,7 @@ func (p Plugin) Exec() error {
 		// fmt.Printf("\n==> FAILED <==\n")
 		logrus.WithFields(logrus.Fields{
 			"status": status,
-		}).Info("Quality Gate Status FAILED")
+		}).Info("Quality Gate Status disabled")
 	}
 	if status == p.Config.Quality {
 		// fmt.Printf("\n==> QUALITY GATEWAY ENALED \n")


### PR DESCRIPTION
I don't know if you're interested in this change but is basically offers the ability to have make a build not wait for the quality gate result. 

I've reused the `WaitQualityGate` to achive this behaviour as the scanner itself is waiting so no need to wait in the code itself . 

If you don't want this just close it as it is :) No hard feelings 🧡