### PR TITLE
workspace relative path fix - only affected by the new param workspace - solution

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,13 +19,13 @@ steps:
     when:
       ref:
         - "refs/pull/**" # Only run for pull requests
-  - name: publish-2.2.0
+  - name: publish-2.2.1
     image: plugins/docker:20
     settings:
       # auto_tag: true
       # auto_tag_suffix: v2.0.2-java17
       tags:
-        - v2.2.0
+        - v2.2.1
         # - latest
         # - stable-java17
       daemon_off: false

--- a/plugin.go
+++ b/plugin.go
@@ -473,9 +473,11 @@ func (p Plugin) Exec() error {
 		params := strings.Split(p.Config.CustomJvmParams, ",")
 		args = append(args, params...)
 	}
-
+	workspaceFolder := ".scannerwork/report-task.txt"
+	
 	if len(p.Config.Workspace) >= 1 {
 		args = append(args, "-Dsonar.projectBaseDir="+p.Config.Workspace)
+		workspaceFolder = p.Config.Workspace+"/.scannerwork/report-task.txt"
 	}
 
 	// Assuming your struct has a print or log method
@@ -531,7 +533,7 @@ func (p Plugin) Exec() error {
 		fmt.Printf("\n==> Sonar Analysis Finished!\n\n")
 		fmt.Printf("\n\nStatic Analysis Result:\n\n")
 
-		cmd = exec.Command("cat", ".scannerwork/report-task.txt")
+		cmd = exec.Command("cat", workspaceFolder)
 
 		cmd.Stdout = os.Stdout
 

--- a/plugin.go
+++ b/plugin.go
@@ -473,11 +473,11 @@ func (p Plugin) Exec() error {
 		params := strings.Split(p.Config.CustomJvmParams, ",")
 		args = append(args, params...)
 	}
-	workspaceFolder := ".scannerwork/report-task.txt"
+	taskFilePath := ".scannerwork/report-task.txt"
 	
 	if len(p.Config.Workspace) >= 1 {
 		args = append(args, "-Dsonar.projectBaseDir="+p.Config.Workspace)
-		workspaceFolder = p.Config.Workspace+"/.scannerwork/report-task.txt"
+		taskFilePath = p.Config.Workspace+"/.scannerwork/report-task.txt"
 	}
 
 	// Assuming your struct has a print or log method
@@ -533,7 +533,7 @@ func (p Plugin) Exec() error {
 		fmt.Printf("\n==> Sonar Analysis Finished!\n\n")
 		fmt.Printf("\n\nStatic Analysis Result:\n\n")
 
-		cmd = exec.Command("cat", workspaceFolder)
+		cmd = exec.Command("cat", taskFilePath)
 
 		cmd.Stdout = os.Stdout
 
@@ -555,7 +555,7 @@ func (p Plugin) Exec() error {
 		fmt.Printf("\n\nParsing Results:\n\n")
 		fmt.Printf("\n")
 
-		report, err := staticScan(&p)
+		report, err := staticScan(&p, taskFilePath)
 
 		if err != nil {
 			logrus.WithFields(logrus.Fields{
@@ -646,9 +646,9 @@ func displayQualityGateStatus(status string, qualityEnabled bool) {
 	fmt.Println(lineBreak)
 }
 
-func staticScan(p *Plugin) (*SonarReport, error) {
+func staticScan(p *Plugin, taskFilePath String) (*SonarReport, error) {
 
-	cmd := exec.Command("sed", "-e", "s/=/=\"/", "-e", "s/$/\"/", ".scannerwork/report-task.txt")
+	cmd := exec.Command("sed", "-e", "s/=/=\"/", "-e", "s/$/\"/", taskFilePath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		logrus.WithFields(logrus.Fields{

--- a/plugin.go
+++ b/plugin.go
@@ -646,7 +646,7 @@ func displayQualityGateStatus(status string, qualityEnabled bool) {
 	fmt.Println(lineBreak)
 }
 
-func staticScan(p *Plugin, taskFilePath String) (*SonarReport, error) {
+func staticScan(p *Plugin, taskFilePath string) (*SonarReport, error) {
 
 	cmd := exec.Command("sed", "-e", "s/=/=\"/", "-e", "s/$/\"/", taskFilePath)
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
This version fix the usage of the workspace param where some files are created in the workspace folder and not in the root folder where plugins is running.

I added the workspace path when used to the files path