### PR TITLE
feat-sonarqualitygate: Added sonarquality gate feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,16 @@ func main() {
 			EnvVar: "PLUGIN_SONAR_TOKEN",
 		},
 		cli.StringFlag{
+			Name:   "organization",
+			Usage:  "SonarQube Organization",
+			EnvVar: "PLUGIN_SONAR_ORGANIZATION",
+		},
+		cli.StringFlag{
+			Name:   "scmDisabled",
+			Usage:  "SonarQube SCM Disabled",
+			EnvVar: "PLUGIN_SCM_DISABLED",
+		},
+		cli.StringFlag{
 			Name:   "ver",
 			Usage:  "Project version",
 			EnvVar: "PLUGIN_BUILD_NUMBER",
@@ -298,6 +308,8 @@ func run(c *cli.Context) {
 			Name:                       c.String("name"),
 			Host:                       c.String("host"),
 			Token:                      c.String("token"),
+			Organization:               c.String("organization"),
+			SCMDisabled:                c.Bool("scmDisabled"),
 			Version:                    c.String("ver"),
 			Branch:                     c.String("branch"),
 			Timeout:                    c.String("timeout"),

--- a/plugin.go
+++ b/plugin.go
@@ -51,6 +51,8 @@ type (
 		Name                       string
 		Host                       string
 		Token                      string
+		Organization               string
+		SCMDisabled                bool
 		Version                    string
 		Branch                     string
 		Sources                    string
@@ -456,6 +458,8 @@ func (p Plugin) Exec() error {
 		configurations := map[string]string{
 			"-Dsonar.projectKey":                     p.Config.Key,
 			"-Dsonar.projectName":                    p.Config.Name,
+			"-Dsonar.organization":                   p.Config.Organization,
+			"-Dsonar.scm.disabled":                   strconv.FormatBool(p.Config.SCMDisabled),
 			"-Dsonar.projectVersion":                 p.Config.Version,
 			"-Dsonar.sources":                        p.Config.Sources,
 			"-Dsonar.ws.timeout":                     p.Config.Timeout,


### PR DESCRIPTION
Added sonar quality support to the existing plugin.

Harness quality gate step:
```
- step:
    identifier: waitforqualitygate6278c9
    name: Sonarqube_Quality_Gate
    spec:
      image: 'plugins/sonarqube-scanner:v2.4.2'
      settings:
        scm_disabled: 'false'
        skip_scan: 'false'
        sonar_host: <+input>
        sonar_key: <+input>
        sonar_name: <+input>
        sonar_organization: <+input>
        sonar_quality_enabled: 'true'
        sonar_qualitygate: OK
        sonar_token: <+input>
        sources: .
        timeout: '300'
    timeout: ''
    type: Plugin
```